### PR TITLE
Log to STDOUT by default, but allow overrides from client code

### DIFF
--- a/lib/elementary/transport/http.rb
+++ b/lib/elementary/transport/http.rb
@@ -17,7 +17,7 @@ module Elementary
       # @param [Hash] opts Options to be passed directly into Faraday.
       def initialize(hosts, opts={})
         @hosts = hosts
-        @options = opts
+        @options = Hashie::Mash.new({:logging => true, :logger => :logger}).merge(opts)
       end
 
       def call(service, rpc_method, *params)
@@ -49,9 +49,11 @@ module Elementary
         return @client if @client
 
         faraday_options = @options.merge({:url => host_url})
+        logging = faraday_options.delete(:logging)
+        logger = faraday_options.delete(:logger)
         @client = Faraday.new(faraday_options) do |f|
           f.request :raise_on_status
-          f.response :logger
+          f.response :logger if logging and logger
           f.adapter :net_http_persistent
         end
         return @client


### PR DESCRIPTION
Presently, all elementary connections log to STDOUT due to the HTTP transport's Faraday configuration. There is no way for client code to configure this.

This isn't great, because in cases where we actually want this data logged, we want control over which logger it goes to. We also want the option to ignore logging data entirely.

The way it's working now is making it hard for us to dig through some of our specs and scaffolding scripts because of how much gets dumped out by Elementary.