### PR TITLE
Can set Concurrent::Executor for returned Future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ tmp
 mkmf.log
 *.swp
 .ruby-*
+.idea
+*.iml

--- a/lib/elementary/connection.rb
+++ b/lib/elementary/connection.rb
@@ -22,6 +22,9 @@ module Elementary
     # @option opts [Hash] :transport_options A +Hash+ of request options that
     #   will be passed down to the transport layer. This will depend on what
     #   options are available by the underlying transport
+    # @option opts [Hash] :future_options A +Hash+ of options to use when
+    #   constructing the Concurrent::Future to run the RPC. In particular, it
+    #   allows specifying the :executor for the Concurrent::Future.
     def initialize(service, opts={})
       opts = Hashie::Mash.new(opts)
 
@@ -34,10 +37,11 @@ module Elementary
       @transport = opts[:transport]
       @hosts = opts[:hosts] || DEFAULT_HOSTS
       @transport_opts = opts[:transport_options] || {}
+      @future_opts = opts[:future_options] || {}
     end
 
     def rpc
-      @rpc ||= Elementary::Executor.new(@service, select_transport)
+      @rpc ||= Elementary::Executor.new(@service, select_transport, @future_opts)
     end
 
     def select_transport

--- a/lib/elementary/executor.rb
+++ b/lib/elementary/executor.rb
@@ -3,16 +3,17 @@ module Elementary
   class Executor
     attr_reader :service, :transport
 
-    def initialize(service, transport)
+    def initialize(service, transport, future_opts={})
       @service = service
       @transport = transport
+      @future_opts = future_opts
     end
 
     def method_missing(method_name, *params)
       rpc_method = service.rpcs[method_name.to_sym]
       # XXX: explode if rpc_method is nil
 
-      future = Elementary::Future.new do
+      future = Elementary::Future.new(@future_opts) do
         # This is effectively a Rack middleware stack. yay.
         #
         # Easiest to think of it like this:

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,4 +1,4 @@
 
 module Elementary
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Actually, this change permits overriding any of the constructor args on
the returned Concurrent::Future when running an RPC, including
providing an :executor.

When constructing the Elementary::Connection, can can provide a hash of
:future_options that are passed down into the Concurrent::Future
constructor.  This makes it easy to get these operations off of the
global thread pools if needed.