### PR TITLE
Better error messages; lookout/elementary-rpc#36

### DIFF
--- a/lib/elementary/transport/http.rb
+++ b/lib/elementary/transport/http.rb
@@ -31,7 +31,7 @@ module Elementary
 
           return rpc_method[:response_type].decode(response.body)
         rescue StandardError => e
-          raise
+          raise e.exception("#{service.name}##{rpc_method.method}: #{e.message}")
         end
       end
 

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,4 +1,4 @@
 
 module Elementary
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -116,7 +116,7 @@ describe Elementary::Connection do
             it { should be_instance_of Elementary::Future }
             it 'should have a connection refused reason' do
               expect(response.reason).not_to be_nil
-              expect(response.reason.to_s).to eq("connection refused: localhost:8090")
+              expect(response.reason.to_s).to include("connection refused: localhost:8090")
             end
           end
 

--- a/spec/sample_elementary_client_spec.rb
+++ b/spec/sample_elementary_client_spec.rb
@@ -7,6 +7,7 @@ def send_and_verify_http_error_503(msg)
   expect(response).to be_rejected
   expect(response.reason.class).to be Elementary::Middleware::HttpStatusError
   expect(response.reason.message).to include("returned an HTTP response status of 503, so an exception was raised.")
+  expect(response.reason.message).to include("Elementary::Rspec::Simple#error")
 end
 
 def send_and_verify_http_error_500(msg)
@@ -14,6 +15,7 @@ def send_and_verify_http_error_500(msg)
   expect(response).to be_rejected
   expect(response.reason.class).to be Elementary::Errors::RPCFailure
   expect(response.reason.message).to include("sample failure")
+  expect(response.reason.message).to include("Elementary::Rspec::Simple#error")
 end
 
 def send_and_verify_http_error_400(msg)
@@ -21,6 +23,7 @@ def send_and_verify_http_error_400(msg)
   expect(response).to be_rejected
   expect(response.reason.class).to be Elementary::Errors::RPCFailure
   expect(response.reason.message).to include("sample bad request data failure")
+  expect(response.reason.message).to include("Elementary::Rspec::Simple#bad_request_data_method")
 end
 
 def send_and_verify_http_error_404(msg)
@@ -28,6 +31,7 @@ def send_and_verify_http_error_404(msg)
   expect(response).to be_rejected
   expect(response.reason.class).to be Elementary::Errors::RPCFailure
   expect(response.reason.message).to include("sample service not found failure")
+  expect(response.reason.message).to include("Elementary::Rspec::Simple#service_not_found_method")
 end
 
 def send_and_verify_connection_refused(msg)
@@ -35,6 +39,7 @@ def send_and_verify_connection_refused(msg)
   expect(response).to be_rejected
   expect(response.reason.class).to be Elementary::Middleware::HttpStatusError
   expect(response.reason.message).to include("connection refused: localhost:8090")
+  expect(response.reason.message).to include("Elementary::Rspec::Simple#error")
 end
 
 # This test requires ha-proxy to be listening at localhost:8080, but no real rpc to be available


### PR DESCRIPTION
Puts the RPC class and method into error messages.