### PR TITLE
Update lookout-statsd for compatibility with Ruby 2.2.

### DIFF
--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby', '~> 0.7.0'
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
-  spec.add_dependency 'lookout-statsd', '~> 0.9.0'
+  spec.add_dependency 'lookout-statsd', '~> 1.0.0'
   spec.add_dependency 'hashie'
 end

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,4 +1,4 @@
 
 module Elementary
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
(See: lookout/statsd#7.  Resolves lookout/elementary-rpc#37.)