### PR TITLE
Upgrade to concurrent-ruby 1.0.0

### DIFF
--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency 'concurrent-ruby', '~> 0.7.0'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0.0'
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'lookout-statsd', '~> 1.0.0'

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.1.4"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
This allows newer libraries implementing elementary-rpc and other dependencies that use the latest version of concurrent-ruby to coexist peacefully