### PR TITLE
Create Http client object in constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ deploy:
   provider: rubygems
   api_key:
     secure: MBokHfxas7tg/cZe1KXWVIjIoVgf4acZuzQ6D7GZW9WWxz2N03VzTGo3k4YF3oFdv+P3EfjwOTp3JUtrgm65EfvtTs7K+5lttU/D8JBeQagbZqCT8PlFUkNyxp0YPkZ5yNRjKxDgHKfTZ0YfEn+2j3qNLD/zdWomSm6iLOdLo6c=
+before_install:
+ - gem install bundler

--- a/lib/elementary/connection.rb
+++ b/lib/elementary/connection.rb
@@ -38,6 +38,8 @@ module Elementary
       @hosts = opts[:hosts] || DEFAULT_HOSTS
       @transport_opts = opts[:transport_options] || {}
       @future_opts = opts[:future_options] || {}
+      # Create exectutor here to avoid threading issues later. See Issue #43
+      rpc
     end
 
     def rpc

--- a/lib/elementary/transport/http.rb
+++ b/lib/elementary/transport/http.rb
@@ -20,6 +20,8 @@ module Elementary
       def initialize(hosts, opts={})
         @hosts = hosts
         @options = Hashie::Mash.new({:logging => true, :logger => nil}).merge(opts)
+        # Create connection here to avoid threading issues later. See Issue #43
+        client
       end
 
       def call(service, rpc_method, *params)

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -69,9 +69,11 @@ describe Elementary::Connection do
         let(:opts) { {:transport_options => transport_opts} }
         let(:transport_opts) do
           Hashie::Mash.new({
-            :timeout => 3,
-            :open_timeout => 1,
-          })
+                             :request => {
+                               :timeout => 3,
+                               :open_timeout => 1,
+                             }
+                           })
         end
 
         it 'should pass request_options to the transport' do

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -59,7 +59,7 @@ describe Elementary::Connection do
       described_class.new(Elementary::Rspec::Simple, opts)
     end
     describe '#select_transport' do
-      subject(:transport) { connection.select_transport }
+      subject(:transport) { connection.rpc.transport }
 
       context 'by default' do
         it { should be_instance_of Elementary::Transport::HTTP }


### PR DESCRIPTION
This fixes issue #43. If the client object is not created in the
contructor (which is called immediately when the Elementary::Rpc
connection is created), then if multiple threads use that connection,
they can run into races. Multiple threads could modify @options in
parallel, or one thread could use @client (which freezes the adapater
list) while another thread was still initializing it).

This also fixes a small bug in the connection spec, which was passing
invalid options in, but were never checked previously. I'm bumping minor
version and not patch for this reason -- there is a slight change in
behavior in this regard.