### PR TITLE
Loosen dependency upon concurrent-ruby version

### DIFF
--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency 'concurrent-ruby', '~> 1.0.0'
+  spec.add_dependency 'concurrent-ruby', '>= 0.7'
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'lookout-statsd', '~> 1.0.0'

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
Since this gem doesn't have any version-specific requirements on the
Concurrent::Ruby gem, allow the caller to pick their version.