### PR TITLE
Remove dependency on Hashie

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ c = Elementary::Connection.new(Echoserv::Simple,
                                    ]
                                  })
 
+# Specify request timeout
+c = Elementary::Connection.new(Echoserv::Simple,
+                                :hosts => hosts,
+                                :transport_options => {
+                                  :request => {
+                                    :timeout => 5,
+                                    :open_timeout => 2,
+                                  }
+                                 })
 
 
 # Create a Protobuf message to send over RPC

--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'lookout-statsd', '~> 1.0.0'
-  spec.add_dependency 'hashie'
 end

--- a/lib/elementary/connection.rb
+++ b/lib/elementary/connection.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'protobuf'
-require 'hashie'
 
 require 'elementary/middleware'
 require 'elementary/transport'
@@ -26,8 +25,6 @@ module Elementary
     #   constructing the Concurrent::Future to run the RPC. In particular, it
     #   allows specifying the :executor for the Concurrent::Future.
     def initialize(service, opts={})
-      opts = Hashie::Mash.new(opts)
-
       if service.nil? || service.superclass != Protobuf::Rpc::Service
         raise ArgumentError,
           "Cannot construct an Elementary::Connection with `#{service}` (#{service.class})"

--- a/lib/elementary/transport/http.rb
+++ b/lib/elementary/transport/http.rb
@@ -19,7 +19,7 @@ module Elementary
       # @param [Hash] opts Options to be passed directly into Faraday.
       def initialize(hosts, opts={})
         @hosts = hosts
-        @options = Hashie::Mash.new({:logging => true, :logger => nil}).merge(opts)
+        @options = {:logging => true, :logger => nil}.merge(opts)
         # Create connection here to avoid threading issues later. See Issue #43
         client
       end

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -68,12 +68,12 @@ describe Elementary::Connection do
       context 'with transport_options' do
         let(:opts) { {:transport_options => transport_opts} }
         let(:transport_opts) do
-          Hashie::Mash.new({
-                             :request => {
-                               :timeout => 3,
-                               :open_timeout => 1,
-                             }
-                           })
+          {
+            :request => {
+              :timeout => 3,
+              :open_timeout => 1,
+            }
+          }
         end
 
         it 'should pass request_options to the transport' do

--- a/spec/transport/http_spec.rb
+++ b/spec/transport/http_spec.rb
@@ -71,6 +71,8 @@ describe Elementary::Transport::HTTP do
       it 'should pass options to Faraday.new' do
         expect(Faraday).to receive(:new).with(hash_including(opts)).and_call_original
         expect(client).to be_instance_of Faraday::Connection
+        expect(client.options.timeout).to eq(3)
+        expect(client.options.open_timeout).to eq(1)
       end
     end
 


### PR DESCRIPTION
Because Faraday assumes a Hash and it ignores some options when
specified in a Hashier::Mash object rather than a option hash.

This made it impossible to specify a timeout to a RPC.

@ismith @dgolombek 