### PR TITLE
Use Statsd#time instead of #timing

### DIFF
--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby', '>= 0.7'
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
-  spec.add_dependency 'lookout-statsd', '~> 3.0'
+  spec.add_dependency 'lookout-statsd', '~> 3.1'
   spec.add_dependency 'hashie'
 end

--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby', '>= 0.7'
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
-  spec.add_dependency 'lookout-statsd', '~> 3.1'
+  spec.add_dependency 'lookout-statsd', '~> 3.2'
   spec.add_dependency 'hashie'
 end

--- a/lib/elementary/middleware/statsd.rb
+++ b/lib/elementary/middleware/statsd.rb
@@ -16,7 +16,7 @@ module Elementary
       end
 
       def call(service, rpc_method, *params)
-        @statsd.timing(metric_name(service.name, rpc_method.method)) do
+        @statsd.time(metric_name(service.name, rpc_method.method)) do
           @app.call(service, rpc_method, *params)
         end
       end

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.8.0"
+  VERSION = "2.9.0"
 end


### PR DESCRIPTION
Lookout-statsd used #timing where other statsd's use #time, but
lookout-statsd now has #time as well, so use that for compatibility.