### PR TITLE
Switch to HTTPClient from Net::HTTP::Persistent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :development do
   gem 'pry'
   gem 'debugger', :platform => :mri_19
   gem 'debugger-pry', :platform => :mri_19
-  gem 'byebug', :platform => [:mri_20, :mri_21]
+  gem 'byebug', :platform => [:mri_20, :mri_21, :mri_22]
 end

--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'concurrent-ruby', '>= 0.7'
   spec.add_dependency 'faraday', '~> 0.9.0'
-  spec.add_dependency 'net-http-persistent', '~> 2.9.4'
+  spec.add_dependency 'httpclient', '~> 2.8'
   spec.add_dependency 'lookout-statsd', '~> 3.2'
   spec.add_dependency 'hashie'
 end

--- a/lib/elementary/transport/http.rb
+++ b/lib/elementary/transport/http.rb
@@ -63,7 +63,7 @@ module Elementary
         @client = Faraday.new(faraday_options) do |f|
           f.request :raise_on_status
           f.response :logger, logger if logging
-          f.adapter :net_http_persistent
+          f.adapter :httpclient
         end
 
         # Adapters aren't middleware, so we have to pop the adapter off before

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.9.0"
+  VERSION = "2.9.1"
 end


### PR DESCRIPTION
In our experience, HTTPClient interacts much better with newest
jruby-openssl gem and Faraday in combination.