### PR TITLE
Loosen Faraday version lock

### DIFF
--- a/elementary-rpc.gemspec
+++ b/elementary-rpc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency 'concurrent-ruby', '>= 0.7'
-  spec.add_dependency 'faraday', '~> 0.9.0'
+  spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'httpclient', '~> 2.8'
   spec.add_dependency 'lookout-statsd', '~> 3.2'
   spec.add_dependency 'hashie'

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.9.1"
+  VERSION = "2.9.2"
 end


### PR DESCRIPTION
Faraday is up to 0.10.1, including several major bug fixes, and it's
backwards compatible.