### PR TITLE
Handle java exceptions better

### DIFF
--- a/lib/elementary/transport/http.rb
+++ b/lib/elementary/transport/http.rb
@@ -36,7 +36,12 @@ module Elementary
 
           return rpc_method[:response_type].decode(response.body)
         rescue StandardError => e
-          raise e.exception("#{service.name}##{rpc_method.method}: #{e.message}")
+          if e.respond_to?(:exception)
+            raise e.exception("#{service.name}##{rpc_method.method}: #{e.message}")
+          else
+            # java.lang.Exceptions don't implement #exception
+            raise e.class.new("#{service.name}##{rpc_method.method}: #{e.message}")
+          end
         end
       end
 

--- a/lib/elementary/version.rb
+++ b/lib/elementary/version.rb
@@ -1,3 +1,3 @@
 module Elementary
-  VERSION = "2.9.2"
+  VERSION = "2.9.3"
 end

--- a/spec/transport/http_spec.rb
+++ b/spec/transport/http_spec.rb
@@ -115,7 +115,7 @@ describe Elementary::Transport::HTTP do
   end
 
   describe "#call" do
-    let(:hosts) { [{}] }
+    let(:hosts) { [{host: 'example.com', port: 80}] }
     let(:service) { double('Protobuf::Service', name: 'fake_service' ) }
     let(:rpc_method) { double('Protobuf::RpcMethod', method: 'fake_method') }
     let(:protobuf) { double('Protobuf', encode: 'encoded_protobuf') }

--- a/spec/transport/http_spec.rb
+++ b/spec/transport/http_spec.rb
@@ -113,4 +113,33 @@ describe Elementary::Transport::HTTP do
       end
     end
   end
+
+  describe "#call" do
+    let(:hosts) { [{}] }
+    let(:service) { double('Protobuf::Service', name: 'fake_service' ) }
+    let(:rpc_method) { double('Protobuf::RpcMethod', method: 'fake_method') }
+    let(:protobuf) { double('Protobuf', encode: 'encoded_protobuf') }
+    subject(:call) { http.call(service, rpc_method, protobuf) }
+
+    context 'raises error' do
+      let(:error) { Elementary::Errors::RPCFailure.new({header_code: 500, header_message: 'rpc_failure'}) }
+      it 'should re-raise' do
+        expect(http).to receive(:client).and_raise(error)
+        expect { subject }.to raise_error error.class, /#{service.name}##{rpc_method.method}: #{error.message}/
+      end
+    end
+
+    if RUBY_PLATFORM == 'java'
+      # Can't easily do this this in MRI -- stubbing respond_to on the
+      # exception to return false for :exception makes RSpec think
+      # it's not an exception
+      context 'raises java exception' do
+        let(:error) { java.net.SocketException.new('oops') }
+        it 'should re-raise' do
+          expect(http).to receive(:client).and_raise(error)
+          expect { subject }.to raise_error error.class, /#{service.name}##{rpc_method.method}: #{error.message}/
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
java.lang.Exceptions don't support #exception and thus weren't rethrowing failures correctly.